### PR TITLE
Added support for theme-color

### DIFF
--- a/src/content-script.js
+++ b/src/content-script.js
@@ -1,0 +1,11 @@
+// 
+// -----------------------------
+var node = null, colorStr = null;
+node = document.querySelector('meta[name="theme-color"]');
+// check if we were able to find the node.
+if (node) {
+    colorStr = node.getAttribute("content");
+}
+// -----------------------------
+// we have to have this line so we can passback the result to background.js.
+colorStr;


### PR DESCRIPTION
## Additions
- Added support for [theme-color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) and is now the default way for obtaining the final page color. The legacy method of image capturing is used as a fallback. **NOTE** I didn't include support for word color values such as `white`, `red`, etc.  [link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color)
- Couple of utility functions for converting between color formats.

## Bugfixes
- Fixed theme not changing when opening an inactive tab. (fixes an old bug where if a tab is old enough clicking on it doesn't result in theme change)
- `indexedColorMap` entries expire after sometime. This is so the cached theme can be refreshed without having to restart the browser.

## Deletions
- Removed not used/useless functions and variables such as `indexedStateMap`.

## Future plans
- Add supports for `prefers-color-scheme` to allow for a more polished experince. It should allow us to default to the dark or light theme incase we are unable to determine what color is appropriate.
- Add the ability to limit how bright or dark the theme is for a more consistent experience accross sites with different levels of light intensity. 